### PR TITLE
Fix(js): Fixed the options crash in new topic pop-up

### DIFF
--- a/assets/javascripts/discourse/initializers/apply-tabs.js.es6
+++ b/assets/javascripts/discourse/initializers/apply-tabs.js.es6
@@ -50,13 +50,11 @@ function initializeTabs(api) {
     {id: 'discourse-rad-plugin-tabs'}
   );
 
-  api.addComposerToolbarPopupMenuOption(() => {
-    return {
+  api.addComposerToolbarPopupMenuOption({
       action: 'insertTabs',
       icon: 'caret-right',
       label: 'tabs.title'
-    };
-  });
+    });
 
   ComposerController.reopen({
     actions: {

--- a/assets/javascripts/discourse/initializers/apply-tabs.js.es6
+++ b/assets/javascripts/discourse/initializers/apply-tabs.js.es6
@@ -50,7 +50,7 @@ function initializeTabs(api) {
     {id: 'discourse-rad-plugin-tabs'}
   );
 
-  api.addToolbarPopupMenuOptionsCallback(() => {
+  api.addComposerToolbarPopupMenuOption(() => {
     return {
       action: 'insertTabs',
       icon: 'caret-right',


### PR DESCRIPTION
Deprecation notice: `addToolbarPopupMenuOptionsCallback` has been renamed to `addComposerToolbarPopupMenuOption` [deprecated since Discourse 3.2] [removal in Discourse 3.3] [deprecation id: discourse.add-toolbar-popup-menu-options-callback]